### PR TITLE
step9_first

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -12,14 +12,22 @@ from pydantic import BaseModel
 from contextlib import asynccontextmanager
 from typing import List
 from typing import Optional
+import sys
+print("✅ print is working!", file=sys.stderr)
+
 
 # 8-2 GitHub Actionの確認
+logging.basicConfig(level=logging.INFO)
+logger=logging.getLogger(__name__)
+
 
 # Define the path to the images & sqlite3 database
 images = pathlib.Path(__file__).parent.resolve() / "images"
 
 db = pathlib.Path(__file__).parent.resolve() / "db" 
 DB_PATH = db / "mercari.sqlite3"  # `db` ディレクトリ内の `mercari.sqlite3`
+print("📁 現在の作業ディレクトリ:", os.getcwd(), file=sys.stderr)
+print("📄 DBファイル:", DB_PATH, file=sys.stderr)
 
 # ディレクトリがない場合は作成
 if not db.exists():
@@ -83,6 +91,12 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+@app.get("/debug-log")
+def debug_log():
+    print("🖨️ printが動きました！")
+    logger.info("📦 logger.info が動きました！")
+    return {"message": "Logged!"}
+
 logger = logging.getLogger("uvicorn")
 logger.level = logging.INFO
 images = pathlib.Path(__file__).parent.resolve() / "images"
@@ -116,6 +130,7 @@ class ItemRequest(BaseModel):
     name: str
     category: str
 
+
 # add_item is a handler to add a new item for POST /items .
 @app.post("/items", response_model=AddItemResponse)
 async def add_item(
@@ -124,7 +139,8 @@ async def add_item(
     image: UploadFile = File(...),
     db: sqlite3.Connection = Depends(get_db),
 ):
-
+    print("🚀 POST /items にリクエストが届いた！", flush=True)
+    
 
     # 入力チェック
     if not name or not category:

--- a/typescript/simple-mercari-web/package.json
+++ b/typescript/simple-mercari-web/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "dev": "vite",
     "start": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/typescript/simple-mercari-web/src/App.css
+++ b/typescript/simple-mercari-web/src/App.css
@@ -2,8 +2,21 @@
   text-align: center;
 }
 
+.app{
+  background-color: #F6F5ED;
+}
+
+.ItemListWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px; /* カードの間のスペース */
+  justify-content: center; /* 真ん中に寄せる */
+}
+
+
+
 .Title {
-  background-color: #222427;
+  background-color: #E72121;
   min-height: 8vh;
   display: flex;
   flex-direction: column;
@@ -11,29 +24,78 @@
   justify-content: left;
   font-size: calc(10px + 1vmin);
   color: white;
+  width: 300px;
 }
 
 .Listing {
-  background-color: #222427;
-  min-height: 8vh;
+  background-color: #FBFAF5;
+  margin: 2rem auto;
+  padding: 2rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  width: 100%;
+  max-width: 600px;
+}
+
+.Listing form {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: left;
-  font-size: calc(10px + 1vmin);
-  color: white;
+  gap: 5rem; /* ← 各要素間のスペース */
+}
+
+.Listing input[type="text"] {
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  width: 200px;
+  background-color: #f9f9f9;
+  color: #333;
+  margin: 3px;
+
+}
+.Listing input[type="file"]{
+  width: 500px;
+  margin: 3px;
+  padding: 0.6rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: #f9f9f9;
+  color: #333;
+}
+
+.Listing button {
+  align-self: center; 
+  padding: 0.75rem 1.5rem;
+  background-color: #FFF5BE;
+  color: #333;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  margin: 3px;
+}
+
+.Listing button:hover {
+  background-color: #F9D134;
 }
 
 .ItemList {
-  background-color: #222427;
-  min-height: 8vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: left;
-  font-size: calc(10px + 1vmin);
-  color: white;
+  padding: 1rem;
+  background-color: #F5F5F5;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  width: 200px;
+  color: #000000;
+  text-align: center;
 }
+
+.ItemList img {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
 
 .App-link {
   color: #61dafb;

--- a/typescript/simple-mercari-web/src/App.tsx
+++ b/typescript/simple-mercari-web/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   // reload ItemList after Listing complete
   const [reload, setReload] = useState(true);
   return (
-    <div>
+    <div className='app'>
       <header className="Title">
         <p>
           <b>Simple Mercari</b>

--- a/typescript/simple-mercari-web/src/api/index.ts
+++ b/typescript/simple-mercari-web/src/api/index.ts
@@ -1,4 +1,6 @@
 const SERVER_URL = import.meta.env.VITE_BACKEND_URL || 'http://127.0.0.1:9000';
+console.log("✅ VITE_BACKEND_URL:", import.meta.env.VITE_BACKEND_URL);
+console.log("🌐 SERVER_URL:", SERVER_URL);
 
 export interface Item {
   id: number;

--- a/typescript/simple-mercari-web/src/components/ItemList.tsx
+++ b/typescript/simple-mercari-web/src/components/ItemList.tsx
@@ -29,12 +29,20 @@ export const ItemList = ({ reload, onLoadCompleted }: Prop) => {
   }, [reload, onLoadCompleted]);
 
   return (
-    <div>
+    <div className="ItemListWrapper">
       {items?.map((item) => {
         return (
           <div key={item.id} className="ItemList">
             {/* TODO: Task 2: Show item images */}
-            <img src={PLACEHOLDER_IMAGE} />
+            <img
+              src={`http://localhost:9000/image/${item.image_name}`}
+              alt={item.name}
+              onError={(e) => {
+              e.currentTarget.src = PLACEHOLDER_IMAGE;
+            }}
+          />
+
+
             <p>
               <span>Name: {item.name}</span>
               <br />

--- a/typescript/simple-mercari-web/tsconfig.app.json
+++ b/typescript/simple-mercari-web/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
@@ -22,8 +23,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## What
1. 新しい商品を登録
2. 商品の画像を Build@Mercari のロゴからhttp://localhost:9000/image/<item_id>.jpgを画像として指定し、一覧画面でそれぞれの画像を表示
3. HTML と CSS を使ってスタイルを変更
　・ロゴを左上に配置
　・Listingフォームをデフォルトのデザインから見やすく
4. グリッドを使ってアイテム一覧の UI を変更
　・各アイテムをカード形式で並べる
　・横にも並ぶように変更
## Why
Web のフロントエンドを実装するため

## Result
↓変更したUI
<img width="1422" alt="スクリーンショット 2025-03-28 11 45 31" src="https://github.com/user-attachments/assets/6686a2f2-1703-446c-ac01-5eecbd3a94ea" />

↓ピアノを商品登録
<img width="777" alt="スクリーンショット 2025-03-28 11 51 22" src="https://github.com/user-attachments/assets/b4e2c63a-6233-4d96-94ec-74f6c6bb151f" />
<img width="266" alt="スクリーンショット 2025-03-28 11 51 29" src="https://github.com/user-attachments/assets/c92bbc08-0628-4a29-9192-f946b243fc8d" />
